### PR TITLE
feat: add endpoint to return residential complexes by authenticated user

### DIFF
--- a/src/residential-complex/application/services/find-residential-complexes-by-user.use-case.ts
+++ b/src/residential-complex/application/services/find-residential-complexes-by-user.use-case.ts
@@ -1,0 +1,16 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { ResidentialComplexInterface } from '../../domain/repositories/residential-complex.repository-interface';
+import { ResidentialComplexResponseDto } from '../dto/residential-complex-response.dto';
+
+@Injectable()
+export class FindResidentialComplexesByUserUseCase {
+  constructor(
+    @Inject('ResidentialComplexInterface')
+    private readonly residentialComplexInterface: ResidentialComplexInterface,
+  ) {}
+
+  async execute(userId: string): Promise<ResidentialComplexResponseDto[]> {
+    const residentialComplexes = await this.residentialComplexInterface.findManyByUserId(userId);
+    return residentialComplexes.map(rc => ResidentialComplexResponseDto.fromEntities(rc));
+  }
+}

--- a/src/residential-complex/domain/repositories/residential-complex.repository-interface.ts
+++ b/src/residential-complex/domain/repositories/residential-complex.repository-interface.ts
@@ -8,6 +8,7 @@ export interface ResidentialComplexInterface {
     conditions: any;
     include?: any;
   }): Promise<ResidentialComplex | null>;
+  findManyByUserId(userId: string): Promise<ResidentialComplex[]>;
   create(residentialComplex: ResidentialComplex): Promise<ResidentialComplex>;
   update(id: string, residentialComplex: Partial<ResidentialComplex>): Promise<ResidentialComplex>;
   delete(id: string): Promise<boolean>;

--- a/src/residential-complex/infrastructure/persistence/residential-complex.repository.prisma.ts
+++ b/src/residential-complex/infrastructure/persistence/residential-complex.repository.prisma.ts
@@ -49,6 +49,23 @@ export class ResidentialComplexPrismaRepository implements ResidentialComplexInt
     });
   }
 
+  async findManyByUserId(userId: string): Promise<ResidentialComplex[]> {
+    const results = await this.prisma.residentialComplex.findMany({
+      where: {
+        userRoles: { some: { userId } },
+      },
+    });
+
+    return results.map(rc =>
+      ResidentialComplex.fromPrisma({
+        ...rc,
+        logo: rc.logo ?? undefined,
+        primaryColor: rc.primaryColor ?? undefined,
+        secondaryColor: rc.secondaryColor ?? undefined,
+      }),
+    );
+  }
+
   async create(residentialComplex: ResidentialComplexProps): Promise<ResidentialComplex> {
     const {
       id: _id,

--- a/src/residential-complex/presentation/residential-complex.controller.ts
+++ b/src/residential-complex/presentation/residential-complex.controller.ts
@@ -9,9 +9,12 @@ import {
   ParseUUIDPipe,
   Patch,
   Post,
+  Req,
   UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
+import { Request } from 'express';
+import { UserProps } from '../../users/domain/entities/user.entity';
 import { AuthGuard } from '@nestjs/passport';
 import { Throttle } from '@nestjs/throttler';
 import { CommonAreaResponseDto } from '../../common-area/application/dto/common-area-response.dto';
@@ -31,6 +34,7 @@ import { ResidentialComplexResponseDto } from '../application/dto/residential-co
 import { UpdateResidentialComplexDto } from '../application/dto/update-residential-complex.dto';
 import { CreateResidentialComplexUseCase } from '../application/services/create-residential-complex.use-case';
 import { DeleteResidentialComplexUseCase } from '../application/services/delete-residential-complex.use-case';
+import { FindResidentialComplexesByUserUseCase } from '../application/services/find-residential-complexes-by-user.use-case';
 import { FindResidentialComplexUseCase } from '../application/services/find-residential-complex.use-case';
 import { UpdateResidentialComplexUseCase } from '../application/services/update-residential-complex.use-case';
 
@@ -39,6 +43,7 @@ import { UpdateResidentialComplexUseCase } from '../application/services/update-
 export class ResidentialComplexController {
   constructor(
     private readonly findResidentialComplexUseCase: FindResidentialComplexUseCase,
+    private readonly findResidentialComplexesByUserUseCase: FindResidentialComplexesByUserUseCase,
     private readonly createResidentialComplexUseCase: CreateResidentialComplexUseCase,
     private readonly updateResidentialComplexUseCase: UpdateResidentialComplexUseCase,
     private readonly deleteResidentialComplexUseCase: DeleteResidentialComplexUseCase,
@@ -123,6 +128,27 @@ export class ResidentialComplexController {
     @Body() updateCommonAreaDto: UpdateCommonAreaDto,
   ): Promise<boolean> {
     return this.updateCommonAreaUseCase.execute(id, commonAreaId, updateCommonAreaDto);
+  }
+
+  @Get('/me')
+  @UseGuards(AuthGuard())
+  @Throttle({ default: { limit: 5, ttl: 60 } })
+  @HttpCode(HttpStatus.OK)
+  @WrapResponse(true)
+  @SetResponseMessageDecorator('Residential complexes retrieved successfully')
+  @EndpointSwaggerDecorator({
+    summary: 'Get residential complexes for the authenticated user',
+    responseType: createDataResponse(
+      ResidentialComplexResponseDto,
+      'Residential complexes retrieved successfully',
+    ),
+    successStatus: HttpStatus.OK,
+    requireAuth: true,
+  })
+  async getResidentialComplexesByUser(
+    @Req() req: Request & { user: Omit<UserProps, 'password'> & { id: string } },
+  ): Promise<ResidentialComplexResponseDto[]> {
+    return this.findResidentialComplexesByUserUseCase.execute(req.user.id);
   }
 
   @Get('/:slug')

--- a/src/residential-complex/residential-complex.module.ts
+++ b/src/residential-complex/residential-complex.module.ts
@@ -4,6 +4,7 @@ import { CommonAreaModule } from '../common-area/common-area.module';
 import { PrismaModule } from '../prisma/prisma.module';
 import { CreateResidentialComplexUseCase } from './application/services/create-residential-complex.use-case';
 import { DeleteResidentialComplexUseCase } from './application/services/delete-residential-complex.use-case';
+import { FindResidentialComplexesByUserUseCase } from './application/services/find-residential-complexes-by-user.use-case';
 import { FindResidentialComplexUseCase } from './application/services/find-residential-complex.use-case';
 import { UpdateResidentialComplexUseCase } from './application/services/update-residential-complex.use-case';
 import { ResidentialComplexPrismaRepository } from './infrastructure/persistence/residential-complex.repository.prisma';
@@ -18,6 +19,7 @@ import { ResidentialComplexController } from './presentation/residential-complex
   ],
   providers: [
     FindResidentialComplexUseCase,
+    FindResidentialComplexesByUserUseCase,
     CreateResidentialComplexUseCase,
     UpdateResidentialComplexUseCase,
     DeleteResidentialComplexUseCase,


### PR DESCRIPTION
## Summary
- Adds `GET /residential-complexes/me` endpoint that returns all residential complexes where the authenticated user (from JWT cookie) has at least one role assigned
- Adds `findManyByUserId` to the repository interface and Prisma implementation using `userRoles: { some: { userId } }` filter
- Extracts logic into a dedicated `FindResidentialComplexesByUserUseCase` (separate from `FindResidentialComplexUseCase` since it returns a collection, not a single entity)

## Test plan
- [ ] Login via `POST /api/auth/login`
- [ ] Call `GET /api/residential-complexes/me` and verify only residential complexes where the user has a role are returned
- [ ] Verify response does not include `towers` or `commonAreas`
- [ ] Verify unauthenticated requests return `401`

🤖 Generated with [Claude Code](https://claude.com/claude-code)