### PR TITLE
feat: get user roles by residential complex + auto-generate password on registration

### DIFF
--- a/src/residential-complex/application/services/register-user-to-complex.use-case.ts
+++ b/src/residential-complex/application/services/register-user-to-complex.use-case.ts
@@ -1,4 +1,5 @@
 import { HttpStatus, Inject, Injectable } from '@nestjs/common';
+import { randomBytes } from 'crypto';
 import { DomainException } from '../../../modules/pino/domain/exceptions/domain.exception';
 import { FindRoleByNameUseCase } from '../../../role/application/services/find-role-by-name.use-case';
 import { userRoleTypes, UserRoleTypes } from '../../../role/domain/enums/user-role-types.enum';
@@ -80,7 +81,12 @@ export class RegisterUserToComplexUseCase {
       return UserResponseDto.fromEntities({ ...existingUser, userDetail: undefined });
     }
 
-    const createdUser = await this.createUserUseCase.create(userData);
+    // TODO: send generatedPassword via email
+    const generatedPassword = `Kbz${randomBytes(8).toString('hex')}!`;
+    const createdUser = await this.createUserUseCase.create({
+      ...userData,
+      password: generatedPassword,
+    });
 
     await this.createUserRoleUseCase.create(
       new UserRole({

--- a/src/user-role/application/dto/user-role-response.dto.ts
+++ b/src/user-role/application/dto/user-role-response.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString } from 'class-validator';
+import { IsEnum, IsOptional, IsString } from 'class-validator';
+import { userRoleTypes, UserRoleTypes } from '../../../role/domain/enums/user-role-types.enum';
 import { UserRole } from '../../domain/entities/user-role.entity';
 
 export class UserRoleResponseDto {
@@ -22,11 +23,22 @@ export class UserRoleResponseDto {
   @IsString()
   residentialComplexId: string;
 
+  @ApiProperty({
+    enum: userRoleTypes,
+    example: userRoleTypes.USER,
+    description: "Role's name",
+    required: false,
+  })
+  @IsEnum(userRoleTypes)
+  @IsOptional()
+  roleName?: UserRoleTypes;
+
   constructor(userRole: UserRole) {
     this.id = userRole.id;
     this.userId = userRole.userId;
     this.roleId = userRole.roleId;
     this.residentialComplexId = userRole.residentialComplexId;
+    this.roleName = userRole.roleName;
   }
 
   static fromEntity(userRole: UserRole): UserRoleResponseDto {

--- a/src/user-role/application/services/find-user-roles-by-complex.use-case.ts
+++ b/src/user-role/application/services/find-user-roles-by-complex.use-case.ts
@@ -1,0 +1,18 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { UserRoleRepositoryInterface } from '../../domain/repositories/user-role.repository-interface';
+import { UserRoleResponseDto } from '../dto/user-role-response.dto';
+
+@Injectable()
+export class FindUserRolesByComplexUseCase {
+  constructor(
+    @Inject('UserRoleRepositoryInterface')
+    private readonly userRoleRepository: UserRoleRepositoryInterface,
+  ) {}
+
+  async execute(userId: string, residentialComplexId: string): Promise<UserRoleResponseDto[]> {
+    const userRoles = await this.userRoleRepository.findMany({
+      conditions: { userId, residentialComplexId },
+    });
+    return userRoles.map(ur => UserRoleResponseDto.fromEntity(ur));
+  }
+}

--- a/src/user-role/domain/entities/user-role.entity.ts
+++ b/src/user-role/domain/entities/user-role.entity.ts
@@ -1,8 +1,11 @@
+import { UserRoleTypes } from '../../../role/domain/enums/user-role-types.enum';
+
 export interface UserRoleProps {
   id?: string;
   userId: string;
   roleId: string;
   residentialComplexId: string;
+  roleName?: UserRoleTypes;
 }
 
 export class UserRole {
@@ -10,12 +13,14 @@ export class UserRole {
   public readonly userId: string;
   public readonly roleId: string;
   public readonly residentialComplexId: string;
+  public readonly roleName?: UserRoleTypes;
 
   constructor(props: UserRoleProps) {
     this.id = props.id;
     this.userId = props.userId;
     this.roleId = props.roleId;
     this.residentialComplexId = props.residentialComplexId;
+    this.roleName = props.roleName;
   }
 
   static fromPrisma(data: UserRoleProps): UserRole {
@@ -24,6 +29,7 @@ export class UserRole {
       userId: data.userId,
       roleId: data.roleId,
       residentialComplexId: data.residentialComplexId,
+      roleName: data.roleName,
     });
   }
 }

--- a/src/user-role/domain/repositories/user-role.repository-interface.ts
+++ b/src/user-role/domain/repositories/user-role.repository-interface.ts
@@ -3,6 +3,7 @@ import { UserRole } from '../entities/user-role.entity';
 export interface UserRoleRepositoryInterface {
   findUnique({ conditions }: { conditions: unknown }): Promise<UserRole | null>;
   findFirst({ conditions }: { conditions: unknown }): Promise<UserRole | null>;
+  findMany({ conditions }: { conditions: unknown }): Promise<UserRole[]>;
   create(userRole: UserRole): Promise<UserRole>;
   delete(id: string): Promise<void>;
 }

--- a/src/user-role/infrastructure/persistence/user-role.repository.prisma.ts
+++ b/src/user-role/infrastructure/persistence/user-role.repository.prisma.ts
@@ -46,6 +46,23 @@ export class UserRolePrismaRepository implements UserRoleRepositoryInterface {
     return UserRole.fromPrisma(created);
   }
 
+  async findMany({ conditions }: { conditions: Prisma.UserRoleWhereInput }): Promise<UserRole[]> {
+    const userRoles = await this.prisma.userRole.findMany({
+      where: conditions,
+      include: { role: true },
+    });
+
+    return userRoles.map(ur =>
+      UserRole.fromPrisma({
+        id: ur.id,
+        userId: ur.userId,
+        roleId: ur.roleId,
+        residentialComplexId: ur.residentialComplexId,
+        roleName: ur.role.name,
+      }),
+    );
+  }
+
   async delete(id: string): Promise<void> {
     await this.prisma.userRole.delete({
       where: { id },

--- a/src/user-role/user-role.module.ts
+++ b/src/user-role/user-role.module.ts
@@ -4,6 +4,7 @@ import { ThrottlerModule } from '@nestjs/throttler';
 import { PrismaModule } from '../prisma/prisma.module';
 import { CreateUserRoleUseCase } from './application/services/create-user-role.use-case';
 import { DeleteUserRoleUseCase } from './application/services/delete-user-role.use-case';
+import { FindUserRolesByComplexUseCase } from './application/services/find-user-roles-by-complex.use-case';
 import { UserRolePrismaRepository } from './infrastructure/persistence/user-role.repository.prisma';
 
 @Module({
@@ -20,11 +21,12 @@ import { UserRolePrismaRepository } from './infrastructure/persistence/user-role
   providers: [
     CreateUserRoleUseCase,
     DeleteUserRoleUseCase,
+    FindUserRolesByComplexUseCase,
     {
       provide: 'UserRoleRepositoryInterface',
       useClass: UserRolePrismaRepository,
     },
   ],
-  exports: [CreateUserRoleUseCase, DeleteUserRoleUseCase],
+  exports: [CreateUserRoleUseCase, DeleteUserRoleUseCase, FindUserRolesByComplexUseCase],
 })
 export class UserRoleModule {}

--- a/src/users/application/dto/create-user.dto.ts
+++ b/src/users/application/dto/create-user.dto.ts
@@ -49,8 +49,8 @@ export class CreateUserDto {
   @IsNotEmpty()
   phone: string;
 
-  @ApiProperty({ example: 'SomeStrongP4ssword!', description: 'User password' })
+  @ApiProperty({ example: 'SomeStrongP4ssword!', description: 'User password', required: false })
   @IsString()
-  @IsNotEmpty()
-  password: string;
+  @IsOptional()
+  password?: string;
 }

--- a/src/users/application/services/create-user.use-case.ts
+++ b/src/users/application/services/create-user.use-case.ts
@@ -26,6 +26,8 @@ export class CreateUserUseCase {
       throw new DomainException(`User with email: ${userData.email} already exits`);
     }
 
+    if (!userData.password) throw new DomainException('Password is required');
+
     const user = new User({ ...userData, isActive: true });
     await user.setPassword(userData.password);
 

--- a/src/users/presentation/users.controller.ts
+++ b/src/users/presentation/users.controller.ts
@@ -6,16 +6,25 @@ import {
   HttpCode,
   HttpStatus,
   Param,
+  ParseUUIDPipe,
   Patch,
   Post,
   Query,
+  Req,
   UseGuards,
+  UseInterceptors,
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { Throttle } from '@nestjs/throttler';
+import { Request } from 'express';
 import { SetResponseMessageDecorator } from '../../common/decorators/set-response-message.decorator';
 import { EndpointSwaggerDecorator } from '../../common/decorators/swagger.decorator';
+import { WrapResponse } from '../../common/decorators/wrap-response.decorator';
+import { createDataResponse } from '../../common/dtos/base-response.dto';
 import { PaginationQueryDto } from '../../common/dtos/pagination-query.dto';
+import { ResponseWrapperInterceptor } from '../../common/interceptors/response-wrapper.interceptor';
+import { UserRoleResponseDto } from '../../user-role/application/dto/user-role-response.dto';
+import { FindUserRolesByComplexUseCase } from '../../user-role/application/services/find-user-roles-by-complex.use-case';
 import { CreateUserDto } from '../application/dto/create-user.dto';
 import { UpdateUserDto } from '../application/dto/update-user.dto';
 import { UserResponseDto } from '../application/dto/user-response.dto';
@@ -24,8 +33,10 @@ import { DeleteUserUseCase } from '../application/services/delete-user.use-case'
 import { FindUsersUseCase } from '../application/services/find-users.use-case';
 import { RegisterUserUseCase } from '../application/services/register-user.use-case';
 import { UpdateUserUseCase } from '../application/services/update-user.use-case';
+import { UserProps } from '../domain/entities/user.entity';
 
 @Controller('users')
+@UseInterceptors(ResponseWrapperInterceptor)
 export class UsersController {
   constructor(
     private readonly findUsersUseCase: FindUsersUseCase,
@@ -33,7 +44,30 @@ export class UsersController {
     private readonly updateUserUseCase: UpdateUserUseCase,
     private readonly activateUserUseCase: ActivateUserUseCase,
     private readonly deleteUserUseCase: DeleteUserUseCase,
+    private readonly findUserRolesByComplexUseCase: FindUserRolesByComplexUseCase,
   ) {}
+
+  @Get('me/roles/residential-complex/:residentialComplexId')
+  @UseGuards(AuthGuard())
+  @Throttle({ default: { limit: 5, ttl: 60 } })
+  @HttpCode(HttpStatus.OK)
+  @WrapResponse(true)
+  @SetResponseMessageDecorator('User roles retrieved successfully')
+  @EndpointSwaggerDecorator({
+    summary: 'Get authenticated user roles in a residential complex',
+    responseType: createDataResponse(UserRoleResponseDto, 'User roles retrieved successfully'),
+    successStatus: HttpStatus.OK,
+    extraResponses: [
+      { status: HttpStatus.BAD_REQUEST, description: 'Residential complex not found' },
+    ],
+    requireAuth: true,
+  })
+  async getUserRolesByComplex(
+    @Req() req: Request & { user: Omit<UserProps, 'password'> & { id: string } },
+    @Param('residentialComplexId', new ParseUUIDPipe()) residentialComplexId: string,
+  ): Promise<UserRoleResponseDto[]> {
+    return this.findUserRolesByComplexUseCase.execute(req.user.id, residentialComplexId);
+  }
 
   @Get()
   @UseGuards(AuthGuard())

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -4,6 +4,7 @@ import { PrismaModule } from '../prisma/prisma.module';
 import { CreateUserDetailUseCase } from '../user-details/application/services/create-user-detail.use-case';
 import { UpdateUserDetailUseCase } from '../user-details/application/services/update-user-detail.use-case';
 import { UserDetailPrismaRepository } from '../user-details/infrastructure/persistence/user-detail.repository.prisma';
+import { UserRoleModule } from '../user-role/user-role.module';
 import { ActivateUserUseCase } from './application/services/activate-user.use-case';
 import { CreateUserUseCase } from './application/services/create-user.use-case';
 import { DeleteUserUseCase } from './application/services/delete-user.use-case';
@@ -15,7 +16,7 @@ import { UsersController } from './presentation/users.controller';
 
 @Module({
   controllers: [UsersController],
-  imports: [PrismaModule, PassportModule.register({ defaultStrategy: 'jwt' })],
+  imports: [PrismaModule, PassportModule.register({ defaultStrategy: 'jwt' }), UserRoleModule],
   providers: [
     FindUsersUseCase,
     CreateUserUseCase,


### PR DESCRIPTION
## Summary

- Added `GET /api/users/me/roles/residential-complex/:residentialComplexId` endpoint to `UsersController` — returns all roles of the authenticated user within a given residential complex
- Extended `UserRoleRepositoryInterface` and `UserRolePrismaRepository` with a `findMany` method that includes the role name via Prisma relation (`include: { role: true }`)
- Added `roleName` field to `UserRole` entity and `UserRoleResponseDto`
- Created `FindUserRolesByComplexUseCase` and wired it into `UserRoleModule` and `UsersModule`
- Password is no longer accepted in the request body when registering a user or admin to a residential complex — a cryptographically random password is now auto-generated internally (`Kbz` + 16 hex chars + `!`) with a `TODO` marker for future email delivery

## Test plan

- [x] `GET /api/users/me/roles/residential-complex/:residentialComplexId` returns all roles for the authenticated user in the given complex, including `roleName`
- [x] `POST /api/residential-complexes/:id/users` registers a new user without requiring `password` in the body
- [x] `POST /api/residential-complexes/:id/admins` registers a new admin without requiring `password` in the body
- [x] TypeScript compiles with no errors
- [x] Pre-commit hooks (prettier, eslint, build) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)