### PR TITLE
fix: replace factory-based swagger response types with concrete named…

### DIFF
--- a/src/apartments/application/dto/get-apartment-parking-lots-response.dto.ts
+++ b/src/apartments/application/dto/get-apartment-parking-lots-response.dto.ts
@@ -1,0 +1,7 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ParkingLotResponseDto } from '../../../parking-lots/application/dto/parking-lot-response.dto';
+
+export class GetApartmentParkingLotsResponseDto {
+  @ApiProperty({ type: [ParkingLotResponseDto], description: "Apartment's parking lots" })
+  items: ParkingLotResponseDto[];
+}

--- a/src/apartments/application/dto/get-apartment-pets-response.dto.ts
+++ b/src/apartments/application/dto/get-apartment-pets-response.dto.ts
@@ -1,0 +1,7 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { PetResponseDto } from '../../../pets/application/dto/pet-response.dto';
+
+export class GetApartmentPetsResponseDto {
+  @ApiProperty({ type: [PetResponseDto], description: "Apartment's pets" })
+  items: PetResponseDto[];
+}

--- a/src/apartments/application/dto/get-apartment-useful-rooms-response.dto.ts
+++ b/src/apartments/application/dto/get-apartment-useful-rooms-response.dto.ts
@@ -1,0 +1,7 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { UsefulRoomResponseDto } from '../../../useful-rooms/application/dto/useful-room-response.dto';
+
+export class GetApartmentUsefulRoomsResponseDto {
+  @ApiProperty({ type: [UsefulRoomResponseDto], description: "Apartment's useful rooms" })
+  items: UsefulRoomResponseDto[];
+}

--- a/src/apartments/application/dto/get-apartment-vehicles-response.dto.ts
+++ b/src/apartments/application/dto/get-apartment-vehicles-response.dto.ts
@@ -1,0 +1,7 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { VehicleResponseDto } from '../../../vehicles/application/dto/vehicle-response.dto';
+
+export class GetApartmentVehiclesResponseDto {
+  @ApiProperty({ type: [VehicleResponseDto], description: "Apartment's vehicles" })
+  items: VehicleResponseDto[];
+}

--- a/src/apartments/presentation/apartments.controller.ts
+++ b/src/apartments/presentation/apartments.controller.ts
@@ -17,7 +17,6 @@ import { Throttle } from '@nestjs/throttler';
 import { SetResponseMessageDecorator } from '../../common/decorators/set-response-message.decorator';
 import { EndpointSwaggerDecorator } from '../../common/decorators/swagger.decorator';
 import { WrapResponse } from '../../common/decorators/wrap-response.decorator';
-import { createBaseResponse, createDataResponse } from '../../common/dtos/base-response.dto';
 import { ComplexRoleGuard, RequiredComplexRoles } from '../../common/guards/complex-role.guard';
 import { ResponseWrapperInterceptor } from '../../common/interceptors/response-wrapper.interceptor';
 import { ParkingLotResponseDto } from '../../parking-lots/application/dto/parking-lot-response.dto';
@@ -30,6 +29,10 @@ import { FindUsefulRoomsByApartmentUseCase } from '../../useful-rooms/applicatio
 import { VehicleResponseDto } from '../../vehicles/application/dto/vehicle-response.dto';
 import { FindVehiclesByApartmentUseCase } from '../../vehicles/application/services/find-vehicles-by-apartment.use-case';
 import { ApartmentResponseDto } from '../application/dto/apartment-response.dto';
+import { GetApartmentParkingLotsResponseDto } from '../application/dto/get-apartment-parking-lots-response.dto';
+import { GetApartmentPetsResponseDto } from '../application/dto/get-apartment-pets-response.dto';
+import { GetApartmentUsefulRoomsResponseDto } from '../application/dto/get-apartment-useful-rooms-response.dto';
+import { GetApartmentVehiclesResponseDto } from '../application/dto/get-apartment-vehicles-response.dto';
 import { CreateApartmentsDto } from '../application/dto/create-apartments.dto';
 import { UpdateApartmentDto } from '../application/dto/update-apartment.dto';
 import { CreateApartmentsUseCase } from '../application/services/create-apartments.use-case';
@@ -59,10 +62,7 @@ export class ApartmentsController {
   @SetResponseMessageDecorator('Apartment retrieved successfully')
   @EndpointSwaggerDecorator({
     summary: "Get tower's or residential complex's apartments",
-    responseType: createDataResponse(
-      ApartmentResponseDto,
-      "Tower's or residential complex's apartment retrieved successfully",
-    ),
+    responseType: ApartmentResponseDto,
     successStatus: HttpStatus.OK,
     extraResponses: [
       {
@@ -88,9 +88,6 @@ export class ApartmentsController {
   @SetResponseMessageDecorator('Apartments added to tower or residential complex successfully')
   @EndpointSwaggerDecorator({
     summary: 'Create apartment',
-    responseType: createBaseResponse(
-      'Apartments added to tower or residential complex successfully',
-    ),
     bodyType: ApartmentResponseDto,
     successStatus: HttpStatus.CREATED,
     extraResponses: [
@@ -168,10 +165,7 @@ export class ApartmentsController {
   @SetResponseMessageDecorator("Apartment's parking lots retrieved successfully")
   @EndpointSwaggerDecorator({
     summary: "Get apartment's parking lots",
-    responseType: createDataResponse(
-      ParkingLotResponseDto,
-      "Apartment's parking lots retrieved successfully",
-    ),
+    responseType: GetApartmentParkingLotsResponseDto,
     successStatus: HttpStatus.OK,
     extraResponses: [{ status: HttpStatus.BAD_REQUEST, description: 'Apartment not found' }],
     requireAuth: true,
@@ -190,10 +184,7 @@ export class ApartmentsController {
   @SetResponseMessageDecorator('Apartment vehicles retrieved successfully')
   @EndpointSwaggerDecorator({
     summary: "Get apartment's vehicles",
-    responseType: createDataResponse(
-      VehicleResponseDto,
-      "Apartment's vehicles retrieved successfully",
-    ),
+    responseType: GetApartmentVehiclesResponseDto,
     successStatus: HttpStatus.OK,
     extraResponses: [{ status: HttpStatus.BAD_REQUEST, description: 'Apartment not found' }],
     requireAuth: true,
@@ -212,7 +203,7 @@ export class ApartmentsController {
   @SetResponseMessageDecorator('Apartment pets retrieved successfully')
   @EndpointSwaggerDecorator({
     summary: "Get apartment's pets",
-    responseType: createDataResponse(PetResponseDto, "Apartment's pets retrieved successfully"),
+    responseType: GetApartmentPetsResponseDto,
     successStatus: HttpStatus.OK,
     extraResponses: [{ status: HttpStatus.BAD_REQUEST, description: 'Apartment not found' }],
     requireAuth: true,
@@ -229,10 +220,7 @@ export class ApartmentsController {
   @SetResponseMessageDecorator('Apartment useful rooms retrieved successfully')
   @EndpointSwaggerDecorator({
     summary: "Get apartment's useful rooms",
-    responseType: createDataResponse(
-      UsefulRoomResponseDto,
-      "Apartment's useful rooms retrieved successfully",
-    ),
+    responseType: GetApartmentUsefulRoomsResponseDto,
     successStatus: HttpStatus.OK,
     extraResponses: [{ status: HttpStatus.BAD_REQUEST, description: 'Apartment not found' }],
     requireAuth: true,

--- a/src/common-area/presentation/common-area.controller.ts
+++ b/src/common-area/presentation/common-area.controller.ts
@@ -17,7 +17,6 @@ import { Throttle } from '@nestjs/throttler';
 import { SetResponseMessageDecorator } from '../../common/decorators/set-response-message.decorator';
 import { EndpointSwaggerDecorator } from '../../common/decorators/swagger.decorator';
 import { WrapResponse } from '../../common/decorators/wrap-response.decorator';
-import { createBaseResponse, createDataResponse } from '../../common/dtos/base-response.dto';
 import { ComplexRoleGuard, RequiredComplexRoles } from '../../common/guards/complex-role.guard';
 import { ResponseWrapperInterceptor } from '../../common/interceptors/response-wrapper.interceptor';
 import { userRoleTypes } from '../../role/domain/enums/user-role-types.enum';
@@ -47,10 +46,7 @@ export class CommonAreaController {
   @SetResponseMessageDecorator('Common area retrieved successfully')
   @EndpointSwaggerDecorator({
     summary: "Get residential complex's common area",
-    responseType: createDataResponse(
-      CommonAreaResponseDto,
-      "Residential complex's common area retrieved successfully",
-    ),
+    responseType: CommonAreaResponseDto,
     successStatus: HttpStatus.OK,
     extraResponses: [{ status: HttpStatus.BAD_REQUEST, description: 'Common area not found' }],
     requireAuth: true,
@@ -71,7 +67,6 @@ export class CommonAreaController {
   @SetResponseMessageDecorator('Common areas added to residential complex successfully')
   @EndpointSwaggerDecorator({
     summary: 'Create common areas',
-    responseType: createBaseResponse('Common areas added to residential complex successfully'),
     bodyType: CreateCommonAreasDto,
     successStatus: HttpStatus.CREATED,
     extraResponses: [

--- a/src/parking-lots/presentation/parking-lots.controller.ts
+++ b/src/parking-lots/presentation/parking-lots.controller.ts
@@ -17,7 +17,6 @@ import { Throttle } from '@nestjs/throttler';
 import { SetResponseMessageDecorator } from '../../common/decorators/set-response-message.decorator';
 import { EndpointSwaggerDecorator } from '../../common/decorators/swagger.decorator';
 import { WrapResponse } from '../../common/decorators/wrap-response.decorator';
-import { createBaseResponse, createDataResponse } from '../../common/dtos/base-response.dto';
 import { ComplexRoleGuard, RequiredComplexRoles } from '../../common/guards/complex-role.guard';
 import { ResponseWrapperInterceptor } from '../../common/interceptors/response-wrapper.interceptor';
 import { userRoleTypes } from '../../role/domain/enums/user-role-types.enum';
@@ -47,10 +46,7 @@ export class ParkingLotsController {
   @SetResponseMessageDecorator('Parking lot retrieved successfully')
   @EndpointSwaggerDecorator({
     summary: "Get residential complex's parking lot",
-    responseType: createDataResponse(
-      ParkingLotResponseDto,
-      "Residential complex's parking lot retrieved successfully",
-    ),
+    responseType: ParkingLotResponseDto,
     successStatus: HttpStatus.OK,
     extraResponses: [{ status: HttpStatus.BAD_REQUEST, description: 'Parking lot not found' }],
     requireAuth: true,
@@ -71,7 +67,6 @@ export class ParkingLotsController {
   @SetResponseMessageDecorator('Parking lots added to residential complex successfully')
   @EndpointSwaggerDecorator({
     summary: 'Create parking lots',
-    responseType: createBaseResponse('Parking lots added to residential complex successfully'),
     bodyType: CreateParkingLotsDto,
     successStatus: HttpStatus.CREATED,
     extraResponses: [

--- a/src/pets/presentation/pets.controller.ts
+++ b/src/pets/presentation/pets.controller.ts
@@ -17,7 +17,6 @@ import { Throttle } from '@nestjs/throttler';
 import { SetResponseMessageDecorator } from '../../common/decorators/set-response-message.decorator';
 import { EndpointSwaggerDecorator } from '../../common/decorators/swagger.decorator';
 import { WrapResponse } from '../../common/decorators/wrap-response.decorator';
-import { createBaseResponse, createDataResponse } from '../../common/dtos/base-response.dto';
 import { ResponseWrapperInterceptor } from '../../common/interceptors/response-wrapper.interceptor';
 import { CreatePetsDto } from '../application/dto/create-pets.dto';
 import { PetResponseDto } from '../application/dto/pet-response.dto';
@@ -45,7 +44,7 @@ export class PetsController {
   @SetResponseMessageDecorator('Pet retrieved successfully')
   @EndpointSwaggerDecorator({
     summary: "Get apartment's pet",
-    responseType: createDataResponse(PetResponseDto, "Apartment's pet retrieved successfully"),
+    responseType: PetResponseDto,
     successStatus: HttpStatus.OK,
     extraResponses: [{ status: HttpStatus.BAD_REQUEST, description: 'Pet not found' }],
     requireAuth: true,
@@ -65,7 +64,6 @@ export class PetsController {
   @SetResponseMessageDecorator('Pets added to apartment successfully')
   @EndpointSwaggerDecorator({
     summary: 'Create pets',
-    responseType: createBaseResponse('Pets added to apartment successfully'),
     bodyType: CreatePetsDto,
     successStatus: HttpStatus.CREATED,
     extraResponses: [{ status: HttpStatus.BAD_REQUEST, description: 'Apartment not found' }],

--- a/src/residential-complex/application/dto/get-my-residential-complexes-response.dto.ts
+++ b/src/residential-complex/application/dto/get-my-residential-complexes-response.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ResidentialComplexResponseDto } from './residential-complex-response.dto';
+
+export class GetMyResidentialComplexesResponseDto {
+  @ApiProperty({
+    type: [ResidentialComplexResponseDto],
+    description: "User's residential complexes",
+  })
+  items: ResidentialComplexResponseDto[];
+}

--- a/src/residential-complex/application/dto/get-residential-complex-common-areas-response.dto.ts
+++ b/src/residential-complex/application/dto/get-residential-complex-common-areas-response.dto.ts
@@ -1,0 +1,7 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { CommonAreaResponseDto } from '../../../common-area/application/dto/common-area-response.dto';
+
+export class GetResidentialComplexCommonAreasResponseDto {
+  @ApiProperty({ type: [CommonAreaResponseDto], description: "Residential complex's common areas" })
+  items: CommonAreaResponseDto[];
+}

--- a/src/residential-complex/application/dto/get-residential-complex-parking-lots-response.dto.ts
+++ b/src/residential-complex/application/dto/get-residential-complex-parking-lots-response.dto.ts
@@ -1,0 +1,7 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ParkingLotResponseDto } from '../../../parking-lots/application/dto/parking-lot-response.dto';
+
+export class GetResidentialComplexParkingLotsResponseDto {
+  @ApiProperty({ type: [ParkingLotResponseDto], description: "Residential complex's parking lots" })
+  items: ParkingLotResponseDto[];
+}

--- a/src/residential-complex/application/dto/get-residential-complex-towers-response.dto.ts
+++ b/src/residential-complex/application/dto/get-residential-complex-towers-response.dto.ts
@@ -1,0 +1,7 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { TowerResponseDto } from '../../../towers/application/dto/tower-response.dto';
+
+export class GetResidentialComplexTowersResponseDto {
+  @ApiProperty({ type: [TowerResponseDto], description: "Residential complex's towers" })
+  items: TowerResponseDto[];
+}

--- a/src/residential-complex/presentation/residential-complex.controller.ts
+++ b/src/residential-complex/presentation/residential-complex.controller.ts
@@ -21,7 +21,6 @@ import { FindCommonAreasByResidentialComplexUseCase } from '../../common-area/ap
 import { SetResponseMessageDecorator } from '../../common/decorators/set-response-message.decorator';
 import { EndpointSwaggerDecorator } from '../../common/decorators/swagger.decorator';
 import { WrapResponse } from '../../common/decorators/wrap-response.decorator';
-import { createBaseResponse, createDataResponse } from '../../common/dtos/base-response.dto';
 import { ComplexRoleGuard, RequiredComplexRoles } from '../../common/guards/complex-role.guard';
 import { RequiredUserTypes, UserTypeGuard } from '../../common/guards/user-type.guard';
 import { ResponseWrapperInterceptor } from '../../common/interceptors/response-wrapper.interceptor';
@@ -35,6 +34,10 @@ import { UserResponseDto } from '../../users/application/dto/user-response.dto';
 import { UserProps } from '../../users/domain/entities/user.entity';
 import { userTypes } from '../../users/domain/enums/user-types.enum';
 import { CreateResidentialComplexDto } from '../application/dto/create-residential-complex.dto';
+import { GetMyResidentialComplexesResponseDto } from '../application/dto/get-my-residential-complexes-response.dto';
+import { GetResidentialComplexCommonAreasResponseDto } from '../application/dto/get-residential-complex-common-areas-response.dto';
+import { GetResidentialComplexParkingLotsResponseDto } from '../application/dto/get-residential-complex-parking-lots-response.dto';
+import { GetResidentialComplexTowersResponseDto } from '../application/dto/get-residential-complex-towers-response.dto';
 import { ResidentialComplexResponseDto } from '../application/dto/residential-complex-response.dto';
 import { UpdateResidentialComplexDto } from '../application/dto/update-residential-complex.dto';
 import { CreateResidentialComplexUseCase } from '../application/services/create-residential-complex.use-case';
@@ -67,10 +70,7 @@ export class ResidentialComplexController {
   @SetResponseMessageDecorator("Residential complex's common areas retrieved successfully")
   @EndpointSwaggerDecorator({
     summary: "Get residential complex's common areas",
-    responseType: createDataResponse(
-      CommonAreaResponseDto,
-      "Residential complex's common areas retrieved successfully",
-    ),
+    responseType: GetResidentialComplexCommonAreasResponseDto,
     successStatus: HttpStatus.OK,
     extraResponses: [
       { status: HttpStatus.BAD_REQUEST, description: 'Residential complex not found' },
@@ -91,10 +91,7 @@ export class ResidentialComplexController {
   @SetResponseMessageDecorator("Residential complex's towers retrieved successfully")
   @EndpointSwaggerDecorator({
     summary: "Get residential complex's towers",
-    responseType: createDataResponse(
-      TowerResponseDto,
-      "Residential complex's towers retrieved successfully",
-    ),
+    responseType: GetResidentialComplexTowersResponseDto,
     successStatus: HttpStatus.OK,
     extraResponses: [
       { status: HttpStatus.BAD_REQUEST, description: 'Residential complex not found' },
@@ -115,10 +112,7 @@ export class ResidentialComplexController {
   @SetResponseMessageDecorator("Residential complex's parking lots retrieved successfully")
   @EndpointSwaggerDecorator({
     summary: "Get residential complex's parking lots",
-    responseType: createDataResponse(
-      ParkingLotResponseDto,
-      "Residential complex's parking lots retrieved successfully",
-    ),
+    responseType: GetResidentialComplexParkingLotsResponseDto,
     successStatus: HttpStatus.OK,
     extraResponses: [
       { status: HttpStatus.BAD_REQUEST, description: 'Residential complex not found' },
@@ -139,10 +133,7 @@ export class ResidentialComplexController {
   @SetResponseMessageDecorator('Residential complexes retrieved successfully')
   @EndpointSwaggerDecorator({
     summary: 'Get residential complexes for the authenticated user',
-    responseType: createDataResponse(
-      ResidentialComplexResponseDto,
-      'Residential complexes retrieved successfully',
-    ),
+    responseType: GetMyResidentialComplexesResponseDto,
     successStatus: HttpStatus.OK,
     requireAuth: true,
   })
@@ -160,10 +151,7 @@ export class ResidentialComplexController {
   @SetResponseMessageDecorator('Residential complex retrieved successfully')
   @EndpointSwaggerDecorator({
     summary: 'Get residential complex by slug',
-    responseType: createDataResponse(
-      ResidentialComplexResponseDto,
-      'Residential complex retrieved successfully',
-    ),
+    responseType: ResidentialComplexResponseDto,
     successStatus: HttpStatus.OK,
     extraResponses: [
       {
@@ -186,7 +174,7 @@ export class ResidentialComplexController {
   @SetResponseMessageDecorator('Residential complex created successfully')
   @EndpointSwaggerDecorator({
     summary: 'Create residential complex',
-    responseType: createBaseResponse('Residential complex created successfully'),
+    responseType: ResidentialComplexResponseDto,
     bodyType: CreateResidentialComplexDto,
     successStatus: HttpStatus.CREATED,
     extraResponses: [
@@ -213,7 +201,7 @@ export class ResidentialComplexController {
   @SetResponseMessageDecorator('Residential complex updated successfully')
   @EndpointSwaggerDecorator({
     summary: 'Update a residential complex',
-    responseType: createBaseResponse('Residential complex updated successfully'),
+    responseType: ResidentialComplexResponseDto,
     bodyType: UpdateResidentialComplexDto,
     successStatus: HttpStatus.OK,
     extraResponses: [
@@ -244,7 +232,6 @@ export class ResidentialComplexController {
   @SetResponseMessageDecorator('Residential complex deleted successfully')
   @EndpointSwaggerDecorator({
     summary: 'Create residential complex',
-    responseType: createBaseResponse('Residential complex deleted successfully'),
     bodyType: UpdateResidentialComplexDto,
     successStatus: HttpStatus.NO_CONTENT,
     extraResponses: [

--- a/src/towers/presentation/towers.controller.ts
+++ b/src/towers/presentation/towers.controller.ts
@@ -17,7 +17,6 @@ import { Throttle } from '@nestjs/throttler';
 import { SetResponseMessageDecorator } from '../../common/decorators/set-response-message.decorator';
 import { EndpointSwaggerDecorator } from '../../common/decorators/swagger.decorator';
 import { WrapResponse } from '../../common/decorators/wrap-response.decorator';
-import { createBaseResponse, createDataResponse } from '../../common/dtos/base-response.dto';
 import { ComplexRoleGuard, RequiredComplexRoles } from '../../common/guards/complex-role.guard';
 import { ResponseWrapperInterceptor } from '../../common/interceptors/response-wrapper.interceptor';
 import { userRoleTypes } from '../../role/domain/enums/user-role-types.enum';
@@ -47,10 +46,7 @@ export class TowersController {
   @SetResponseMessageDecorator('Tower retrieved successfully')
   @EndpointSwaggerDecorator({
     summary: "Get residential complex's towers",
-    responseType: createDataResponse(
-      TowerResponseDto,
-      "Residential complex's tower retrieved successfully",
-    ),
+    responseType: TowerResponseDto,
     successStatus: HttpStatus.OK,
     extraResponses: [
       {
@@ -76,7 +72,6 @@ export class TowersController {
   @SetResponseMessageDecorator('Towers added to residential complex successfully')
   @EndpointSwaggerDecorator({
     summary: 'Create tower',
-    responseType: createBaseResponse('Towers added to residential complex successfully'),
     bodyType: TowerResponseDto,
     successStatus: HttpStatus.CREATED,
     extraResponses: [

--- a/src/useful-rooms/presentation/useful-rooms.controller.ts
+++ b/src/useful-rooms/presentation/useful-rooms.controller.ts
@@ -17,7 +17,6 @@ import { Throttle } from '@nestjs/throttler';
 import { SetResponseMessageDecorator } from '../../common/decorators/set-response-message.decorator';
 import { EndpointSwaggerDecorator } from '../../common/decorators/swagger.decorator';
 import { WrapResponse } from '../../common/decorators/wrap-response.decorator';
-import { createBaseResponse, createDataResponse } from '../../common/dtos/base-response.dto';
 import { ComplexRoleGuard, RequiredComplexRoles } from '../../common/guards/complex-role.guard';
 import { ResponseWrapperInterceptor } from '../../common/interceptors/response-wrapper.interceptor';
 import { userRoleTypes } from '../../role/domain/enums/user-role-types.enum';
@@ -47,10 +46,7 @@ export class UsefulRoomsController {
   @SetResponseMessageDecorator('Useful room retrieved successfully')
   @EndpointSwaggerDecorator({
     summary: "Get apartment's useful room",
-    responseType: createDataResponse(
-      UsefulRoomResponseDto,
-      "Apartment's useful room retrieved successfully",
-    ),
+    responseType: UsefulRoomResponseDto,
     successStatus: HttpStatus.OK,
     extraResponses: [{ status: HttpStatus.BAD_REQUEST, description: 'Useful room not found' }],
     requireAuth: true,
@@ -71,7 +67,6 @@ export class UsefulRoomsController {
   @SetResponseMessageDecorator('Useful rooms added to apartment successfully')
   @EndpointSwaggerDecorator({
     summary: 'Create useful rooms',
-    responseType: createBaseResponse('Useful rooms added to apartment successfully'),
     bodyType: CreateUsefulRoomsDto,
     successStatus: HttpStatus.CREATED,
     extraResponses: [{ status: HttpStatus.BAD_REQUEST, description: 'Apartment not found' }],

--- a/src/users/application/dto/get-user-roles-response.dto.ts
+++ b/src/users/application/dto/get-user-roles-response.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { UserRoleResponseDto } from '../../../user-role/application/dto/user-role-response.dto';
+
+export class GetUserRolesResponseDto {
+  @ApiProperty({
+    type: [UserRoleResponseDto],
+    description: "User's roles in the residential complex",
+  })
+  items: UserRoleResponseDto[];
+}

--- a/src/users/presentation/users.controller.ts
+++ b/src/users/presentation/users.controller.ts
@@ -20,12 +20,12 @@ import { Request } from 'express';
 import { SetResponseMessageDecorator } from '../../common/decorators/set-response-message.decorator';
 import { EndpointSwaggerDecorator } from '../../common/decorators/swagger.decorator';
 import { WrapResponse } from '../../common/decorators/wrap-response.decorator';
-import { createDataResponse } from '../../common/dtos/base-response.dto';
 import { PaginationQueryDto } from '../../common/dtos/pagination-query.dto';
 import { RequiredUserTypes, UserTypeGuard } from '../../common/guards/user-type.guard';
 import { ResponseWrapperInterceptor } from '../../common/interceptors/response-wrapper.interceptor';
 import { UserRoleResponseDto } from '../../user-role/application/dto/user-role-response.dto';
 import { FindUserRolesByComplexUseCase } from '../../user-role/application/services/find-user-roles-by-complex.use-case';
+import { GetUserRolesResponseDto } from '../application/dto/get-user-roles-response.dto';
 import { CreateUserDto } from '../application/dto/create-user.dto';
 import { UpdateUserDto } from '../application/dto/update-user.dto';
 import { UserResponseDto } from '../application/dto/user-response.dto';
@@ -57,7 +57,7 @@ export class UsersController {
   @SetResponseMessageDecorator('User roles retrieved successfully')
   @EndpointSwaggerDecorator({
     summary: 'Get authenticated user roles in a residential complex',
-    responseType: createDataResponse(UserRoleResponseDto, 'User roles retrieved successfully'),
+    responseType: GetUserRolesResponseDto,
     successStatus: HttpStatus.OK,
     extraResponses: [
       { status: HttpStatus.BAD_REQUEST, description: 'Residential complex not found' },

--- a/src/vehicles/presentation/vehicles.controller.ts
+++ b/src/vehicles/presentation/vehicles.controller.ts
@@ -17,7 +17,6 @@ import { Throttle } from '@nestjs/throttler';
 import { SetResponseMessageDecorator } from '../../common/decorators/set-response-message.decorator';
 import { EndpointSwaggerDecorator } from '../../common/decorators/swagger.decorator';
 import { WrapResponse } from '../../common/decorators/wrap-response.decorator';
-import { createBaseResponse, createDataResponse } from '../../common/dtos/base-response.dto';
 import { ResponseWrapperInterceptor } from '../../common/interceptors/response-wrapper.interceptor';
 import { CreateVehiclesDto } from '../application/dto/create-vehicles.dto';
 import { UpdateVehicleDto } from '../application/dto/update-vehicle.dto';
@@ -45,10 +44,7 @@ export class VehiclesController {
   @SetResponseMessageDecorator('Vehicle retrieved successfully')
   @EndpointSwaggerDecorator({
     summary: "Get apartment's vehicle",
-    responseType: createDataResponse(
-      VehicleResponseDto,
-      "Apartment's vehicle retrieved successfully",
-    ),
+    responseType: VehicleResponseDto,
     successStatus: HttpStatus.OK,
     extraResponses: [{ status: HttpStatus.BAD_REQUEST, description: 'Vehicle not found' }],
     requireAuth: true,
@@ -68,7 +64,6 @@ export class VehiclesController {
   @SetResponseMessageDecorator('Vehicles added to apartment successfully')
   @EndpointSwaggerDecorator({
     summary: 'Create vehicles',
-    responseType: createBaseResponse('Vehicles added to apartment successfully'),
     bodyType: CreateVehiclesDto,
     successStatus: HttpStatus.CREATED,
     extraResponses: [{ status: HttpStatus.BAD_REQUEST, description: 'Apartment not found' }],


### PR DESCRIPTION
… DTOs

Replaced createDataResponse/createBaseResponse factory calls with unique, concrete DTO classes per endpoint to fix duplicate schema collisions in Swagger and ensure each endpoint shows the correct response example.